### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,6 +12,7 @@
 # some basic default values...
 [defaults]
 inventory      = /opt/ansible/inventory/aws_ec2.yml
+interpreter_python=auto_silent  # avoid errors
 
 [inventory]
 enable_plugins = aws_ec2


### PR DESCRIPTION
added interpreter_python=auto_silent    to ansible.cfg to avoid this error 
```
[ec2-user@ip-172-31-27-67 ~]$ ansible all -a  'free -m'
[WARNING]: Platform linux on host ec2-54-90-117-77.compute-1.amazonaws.com is
using the discovered Python interpreter at /usr/bin/python, but future
installation of another Python interpreter could change this. See https://docs.
ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for
more information.
```